### PR TITLE
Feature/save button function

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
     </section>
     <section class="saved-section">
       <h3 class="saved-header">Saved Palettes</h3>
+        <p class="saved-palettes-status">No saved palettes (yet)!
+        </p>
     </section>
   </body>
   <script type="text/javascript" src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -1,9 +1,12 @@
-var newPalette = document.querySelector(".new-palette-button");
+var newPaletteButton = document.querySelector(".new-palette-button");
+var saveButton = document.querySelector(".save-palette-button")
 var lock1 = document.querySelector('#lock1');
 var lock2 = document.querySelector('#lock2');
 var lock3 = document.querySelector('#lock3');
 var lock4 = document.querySelector('#lock4');
 var lock5 = document.querySelector('#lock5');
+
+var savedStatus = document.querySelector(".saved-palettes-status")
 
 var boxes = [
     {box: document.querySelector('#box1'), label: document.querySelector('#label1'), locked: false},
@@ -15,12 +18,12 @@ var boxes = [
 
 var currentPalette = [];
 var lockedColors = [];
+var savedPalettes = [];
 
 addEventListener("load", showRandomColors);
 
-newPalette.addEventListener("click", function(){
-    showRandomColors();
-})
+newPaletteButton.addEventListener("click", showRandomColors);
+saveButton.addEventListener("click", saveCurrentPalette);
 
 function showRandomColors() {
     currentPalette = [];
@@ -38,6 +41,13 @@ function showRandomColors() {
     });
 };
 
+function saveCurrentPalette() {
+    savedStatus.classList.add("hidden")
+    if (!savedPalettes.includes(currentPalette)){
+        savedPalettes.push(currentPalette);
+        return savedPalettes
+    }
+};
 
 lock1.addEventListener('click', function() {
   console.log('here');

--- a/styles.css
+++ b/styles.css
@@ -97,7 +97,10 @@ header {
 
 .saved-section {
 display: flex;
-justify-content: center;
+flex-direction: column;
+justify-content: start;
+align-items: center;
+flex-wrap: wrap;
 width:35%;
 border-left: 5px solid black;
 height: 100vh;
@@ -106,4 +109,8 @@ height: 100vh;
 .saved-header{
     font-family: "Poppins", sans-serif;
     font-size: 35px;
+}
+
+.hidden {
+    display: none;
 }


### PR DESCRIPTION
 Description Section for GitHub
# Pull Request
## Description
This request added an initial line of "No Saved Palettes" and added functioning to the "Save Palette" button that removed the text "No Saved Palettes". Future presentation of the saved boxes will need to be displayed. 
## Related Issues
Closes the need for creating a functioning saved button that will soon display saved palettes. 
## Screenshots (if applicable)
N/A
## Changes Made
The "Saved" section is now flexed in a column to display future saved boxes, the "Save Palettes" button now functions and saves the current palettes to an array. If the current saved palettes already exists in the array, it will not save again. 
## Testing
N/A
## Checklist
- [X] The code follows the project's coding standards.
- [ ] Unit tests have been added or updated to cover the changes.
- [X] Documentation has been updated to reflect the changes (if applicable).
- [X] The code compiles without errors.
- [X] The changes have been tested locally and pass all relevant tests.
- [X] All new and existing tests pass.
- [X] The pull request has been reviewed by at least one other contributor.
## Reviewer Instructions
N/A
## Deployment Notes
N/A
## Additional Information
The next clarified step is to ensure the saved boxes will be shown in the Saved section 
